### PR TITLE
Payroll report doesn't include incomplete weeks at the end of the month.

### DIFF
--- a/timepiece/models.py
+++ b/timepiece/models.py
@@ -636,8 +636,7 @@ class PersonRepeatPeriod(models.Model):
 
     def total_monthly_overtime(self, day):
         start = day.replace(day=1)
-        end = start + relativedelta(months=1)
-        weeks = utils.generate_weeks(start=start, end=end)
+        weeks = utils.generate_weeks(start=start, end=utils.get_last_sat(start))
         overtime = Decimal('0.0')
         for week in weeks:
             overtime += self.overtime_hours_in_week(week)

--- a/timepiece/utils.py
+++ b/timepiece/utils.py
@@ -252,6 +252,7 @@ def get_week_start(day=None):
 def get_last_sat(day=None):
     if not day:
         day = date.today()
+    day += relativedelta(months=1)
     return get_week_start(day) - timedelta(days=1)
 
 

--- a/timepiece/views.py
+++ b/timepiece/views.py
@@ -1097,7 +1097,7 @@ def create_edit_person_time_sheet(request, person_id=None):
 @render_with('timepiece/time-sheet/payroll/summary.html')
 @utils.date_filter
 def payroll_summary(request, form, from_date, to_date, status, activity):
-    last_sat = utils.get_last_sat(to_date)
+    last_sat = utils.get_last_sat(from_date)
     all_weeks = utils.generate_weeks(start=from_date, end=last_sat)
     rps = timepiece.PersonRepeatPeriod.objects.select_related(
         'user',
@@ -1106,8 +1106,7 @@ def payroll_summary(request, form, from_date, to_date, status, activity):
         repeat_period__active=True,
     ).order_by('user__last_name')
     for rp in rps:
-        rp.user.summary = rp.summary(from_date, last_sat)
-
+        rp.user.summary = rp.summary(from_date, to_date)
     cals = []
     date = from_date - relativedelta(months=1)
     end_date = from_date + relativedelta(months=1)


### PR DESCRIPTION
[fixed #62] Pushed weekly and personal summaries to the last complete week
