### PR TITLE
[#79] Time sheets "week of" should show monday's date

### DIFF
--- a/timepiece/templates/timepiece/time-sheet/people/view.html
+++ b/timepiece/templates/timepiece/time-sheet/people/view.html
@@ -57,7 +57,7 @@
         {% for entry in entries %}
             {% ifchanged entry.start_time|date:"W" %}
                 <tr>
-                    <th colspan='8'>Week of {{ entry.start_time|date:"m/d/Y (D)" }} </th>
+                    <th colspan='8'>Week of {% week_start entry.start_time %} </th>
                 </tr>
             {% endifchanged %}
             <tr>


### PR DESCRIPTION
Fixed the entry.start_time to use the existing week_start template tag
