### PR TITLE
refs #156 - Changed add/update entry form project queryset to match...

### DIFF
--- a/timepiece/forms.py
+++ b/timepiece/forms.py
@@ -274,7 +274,8 @@ class AddUpdateEntryForm(forms.ModelForm):
         self.user = kwargs.pop('user')
         super(AddUpdateEntryForm, self).__init__(*args, **kwargs)
         self.fields['project'].queryset = timepiece.Project.objects.filter(
-            users=self.user,
+            users=self.user, status__enable_timetracking=True,
+            type__enable_timetracking=True
         )
         #if editing a current entry, remove the end time field
         if self.instance.start_time and not self.instance.end_time:

--- a/timepiece/tests/timesheet.py
+++ b/timepiece/tests/timesheet.py
@@ -306,6 +306,11 @@ class ClockInTest(TimepieceDataTestCase):
         projects = list(response.context['form'].fields['project'].queryset)
         self.assertTrue(self.project in projects)
         self.assertFalse(self.project2 in projects)
+        self.project.status.enable_timetracking = False
+        self.project.status.save()
+        response = self.client.get(self.url)
+        projects = list(response.context['form'].fields['project'].queryset)
+        self.assertTrue(self.project not in projects)
 
     def testClockInLogin(self):
         response = self.client.get(self.url)
@@ -767,7 +772,12 @@ class CreateEditEntry(TimepieceDataTestCase):
         self.assertEqual(response.status_code, 200)
         projects = list(response.context['form'].fields['project'].queryset)
         self.assertTrue(self.project in projects)
-        self.assertFalse(self.project2 in projects)
+        self.assertTrue(self.project2 not in projects)
+        self.project.status.enable_timetracking = False
+        self.project.status.save()
+        response = self.client.get(reverse('timepiece-add'))
+        projects = list(response.context['form'].fields['project'].queryset)
+        self.assertTrue(self.project not in projects)
 
     def testBadActivity(self):
         """


### PR DESCRIPTION
The add/update form was not filtering projects on the type and status having enable_timetracking set to True. I added this to the query and made a test case for both forms.
