### PR TITLE
refs #189 - Added tests and fix

### DIFF
--- a/timepiece/tests/timesheet.py
+++ b/timepiece/tests/timesheet.py
@@ -925,6 +925,15 @@ class StatusTest(TimepieceDataTestCase):
         self.admin.save()
         self.client.login(username='admin', password='abc')
 
+    def login_with_permission(self):
+        """Helper to login as a user with correct permissions"""
+        view_entry_summary = Permission.objects.get(
+            codename=('view_entry_summary'))
+        self.perm_user = User.objects.create_user('perm', 'e@e.com', 'abc')
+        self.perm_user.user_permissions.add(view_entry_summary)
+        self.perm_user.save()
+        self.client.login(username='perm', password='abc')
+
     def test_verify_other_user(self):
         """A user should not be able to verify another's timesheet"""
         entry = self.create_entry({
@@ -1036,7 +1045,7 @@ class StatusTest(TimepieceDataTestCase):
         self.assertEquals(entries[0].status, 'verified')
 
     def testApprovePage(self):
-        self.login_as_admin()
+        self.login_with_permission()
         entry = self.create_entry(data={
             'user': self.user,
             'start_time': datetime.datetime.now() - \

--- a/timepiece/views.py
+++ b/timepiece/views.py
@@ -542,7 +542,7 @@ def view_person_time_sheet(request, user_id):
 @login_required
 def change_person_time_sheet(request, action, user_id, from_date):
     user = get_object_or_404(User, pk=user_id)
-    admin_verify = request.user.is_superuser
+    admin_verify = request.user.has_perm('timepiece.view_entry_summary')
     perm = True
 
     if not admin_verify and action == 'verify' and user != request.user:


### PR DESCRIPTION
Users now cannot approve their own timesheets and they cannot verify or approve other's timesheets.

See #189 for more details.
