### PR TITLE
refs #232 - Changed time to datetime to be precise

### DIFF
--- a/timepiece/views.py
+++ b/timepiece/views.py
@@ -496,7 +496,9 @@ def view_person_time_sheet(request, user_id):
     if not (request.user.has_perm('timepiece.view_entry_summary') or \
         user.pk == request.user.pk):
         return HttpResponseForbidden('Forbidden')
-    from_date = utils.get_month_start(datetime.datetime.today()).date()
+    today_reset = datetime.datetime.today()
+    today_reset = today_reset.replace(hour=0, minute=0, second=0, microsecond=0)
+    from_date = utils.get_month_start(today_reset)
     to_date = from_date + relativedelta(months=1)
     initial = {
         'request_user': request.user,


### PR DESCRIPTION
The error was occurring because the template did not compare dates and datetimes correctly (since dates arent as precise).

Ive changed the date to a datetime and reset the hours/minutes/seconds/microseconds to 0 in order to get the correct comparison.

See #232 for more details.
