### PR TITLE
refs #209 - Created base template for timepiece to use for bootstrap changes

### DIFF
--- a/timepiece/static/timepiece/js/widgets.js
+++ b/timepiece/static/timepiece/js/widgets.js
@@ -1,0 +1,12 @@
+/**
+ * File activating any jQuery UI or Bootstrap widgets
+ */
+
+jQuery(function($) {
+    /* use jQuery-UI to apply a date picker to all crm-date-fields.  If you
+     * wish, substitute your JavaScript library of choice.
+     */
+    $('[name*=date],#id_start_time_0,#id_end_time_0').datepicker({
+        'dateFormat': 'mm/dd/yy'
+    });
+});

--- a/timepiece/templates/timepiece/base.html
+++ b/timepiece/templates/timepiece/base.html
@@ -7,8 +7,7 @@
     {% block javascript %}
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
         <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.18/jquery-ui.min.js"></script>
-        <script src="{{ STATIC_URL }}js/django-crm.js" type="text/javascript"></script>
-        <script src="{{ STATIC_URL }}js/minibooks.js" type="text/javascript"></script>
+        <script src="{{ STATIC_URL }}timepiece/js/widgets.js"></script>
     {% endblock javascript %}
 
     {% block extrajs %}


### PR DESCRIPTION
The base template for timepiece is now standalone and doesnt reference caktus-portal.

Note: Most functionality becomes non-existent due to missing navigation and such and will be restored with the remaining tickets.
