### PR TITLE
refs #251 - Overwrite of pagination template to Bootstrap standards

### DIFF
--- a/timepiece/static/timepiece/less/style.less
+++ b/timepiece/static/timepiece/less/style.less
@@ -17,19 +17,4 @@ body {
             }
         }
     }
-
-    div.pagination {
-        span {
-            float: left;
-            padding: 0 14px;
-            line-height: 34px;
-            text-decoration: none;
-            border: 1px solid #DDD;
-            border-left-width: 0;
-        }
-
-        span:first-child, a:first-child {
-            border-left-width: 1px;
-        }
-    }
 }

--- a/timepiece/templates/pagination/pagination.html
+++ b/timepiece/templates/pagination/pagination.html
@@ -1,0 +1,42 @@
+{% if is_paginated %}
+{% load i18n %}
+<div class="pagination">
+    <ul>
+        {% if page_obj.has_previous %}
+            <li>
+                <a href="?page={{ page_obj.previous_page_number }}{{ getvars }}{{ hashtag }}" class="prev">&laquo; {% trans "previous" %}</a>
+            </li>
+        {% else %}
+            <li class="disabled">
+                <a>&laquo; {% trans "previous" %}</a>
+            </li>
+        {% endif %}
+        {% for page in pages %}
+            {% if page %}
+                {% ifequal page page_obj.number %}
+                <li class="active">
+                    <a>{{ page }}</a>
+                </li>
+                {% else %}
+                <li>
+                    <a href="?page={{ page }}{{ getvars }}{{ hashtag }}">{{ page }}</a>
+                </li>
+                {% endifequal %}
+            {% else %}
+                <li>
+                    <a>...</a>
+                </li>
+            {% endif %}
+        {% endfor %}
+        {% if page_obj.has_next %}
+            <li>
+                <a href="?page={{ page_obj.next_page_number }}{{ getvars }}{{ hashtag }}" class="next">{% trans "next" %} &raquo;</a>
+            </li>
+        {% else %}
+            <li class="disabled">
+                <a class="disabled next">{% trans "next" %} &raquo;</a>
+            </li>
+        {% endif %}
+    </ul>
+</div>
+{% endif %}


### PR DESCRIPTION
The pagination is now styled correctly for short/long pagination. Template uses bootstrap style pagination so it becomes style automatically (instead of rolling out our own styling).
