### PR TITLE
refs #246 - Added template and changed to regular 200 response

### DIFF
--- a/timepiece/templates/timepiece/search_results.html
+++ b/timepiece/templates/timepiece/search_results.html
@@ -1,0 +1,11 @@
+{% extends "timepiece/base.html" %}
+
+{% block title %}Search Results{% endblock title %}
+
+{% block content %}
+    {% if form.errors %}
+        {% for field in form %}
+            {{ field.errors }}
+        {% endfor %}
+    {% endif %}
+{% endblock content %}

--- a/timepiece/views.py
+++ b/timepiece/views.py
@@ -42,7 +42,11 @@ def quick_search(request):
         form = timepiece_forms.QuickSearchForm(request.GET)
         if form.is_valid():
             return HttpResponseRedirect(form.save())
-    return HttpResponse(form.errors['quick_search'], status=500)
+    return render_to_response('timepiece/search_results.html', {
+            'form': form,
+        },
+        context_instance=RequestContext(request)
+    )
 
 
 class CSVMixin(object):


### PR DESCRIPTION
Added a template for search results that displays if there is any form error

Note: Currently all the template is used for is for errors, but can be used for search results in the future if the behavior for searching (redirect directly to selection alone) is ever changed.

See #246 for more details.
