### PR TITLE
refs #259, #260 - Verify approved timesheets

### DIFF
--- a/timepiece/tests/timesheet.py
+++ b/timepiece/tests/timesheet.py
@@ -1034,6 +1034,29 @@ class StatusTest(TimepieceDataTestCase):
         self.perm_user.save()
         self.client.login(username='perm', password='abc')
 
+    def test_no_hours_verify(self):
+        response = self.client.get(self.verify_url, follow=True)
+        self.assertEquals(response.status_code, 200)
+
+        msg = 'You cannot verify/approve a timesheet with no hours'
+        messages = response.context['messages']
+        self.assertEquals(messages._loaded_messages[0].message, msg)
+
+        response = self.client.post(self.verify_url, follow=True)
+        self.assertEquals(messages._loaded_messages[0].message, msg)
+
+    def test_no_hours_approve(self):
+        self.login_with_permission()
+        response = self.client.get(self.approve_url, follow=True)
+        self.assertEquals(response.status_code, 200)
+
+        msg = 'You cannot verify/approve a timesheet with no hours'
+        messages = response.context['messages']
+        self.assertEquals(messages._loaded_messages[0].message, msg)
+
+        response = self.client.post(self.approve_url, follow=True)
+        self.assertEquals(messages._loaded_messages[0].message, msg)
+
     def test_verify_other_user(self):
         """A user should not be able to verify another's timesheet"""
         entry = self.create_entry({

--- a/timepiece/views.py
+++ b/timepiece/views.py
@@ -616,9 +616,7 @@ def change_person_time_sheet(request, action, user_id, from_date):
             'entries.'.format(user.get_full_name())
         messages.info(request, msg)
         return redirect(return_url)
-    if request.POST and request.POST.get('do_action', 'No') == 'Yes':
-        if active_entries:
-            return redirect(return_url)
+    if request.POST.get('do_action') == 'Yes':
         update_status = {
             'verify': 'verified',
             'approve': 'approved',


### PR DESCRIPTION
You receive a message and get redirected when trying to verify/approve a timesheet with no hours.

You receive a message and get redirected if you try to verify/approve a timesheet for an user with an active entry.
