### PR TITLE
refs #258 - Removed message_set, replaced with message.info

### DIFF
--- a/timepiece/views.py
+++ b/timepiece/views.py
@@ -301,12 +301,12 @@ def reject_entry(request, entry_id):
         entry = timepiece.Entry.no_join.get(pk=entry_id)
     except:
         message = 'No such log entry.'
-        messages.info(request, message)
+        messages.error(request, message)
         return redirect(return_url)
 
     if entry.status == 'unverified' or entry.status == 'invoiced':
         msg_text = 'This entry is unverified or is already invoiced'
-        messages.info(request, msg_text)
+        messages.error(request, msg_text)
         return redirect(return_url)
 
     if request.POST.get('Yes'):


### PR DESCRIPTION
User.message_set was removed in Django 1.4 and was causing tests to fail. In order to make timepiece compliant with both versions 1.3.1 and 1.4, calls to message_set were removed and instead replaced with message.info().

Note: To run the tests against Django 1.4, use tox.
