### PR TITLE
refs #280 - Replace unstyled nav with pills

### DIFF
--- a/timepiece/templates/timepiece/time-sheet/reports/general_ledger.html
+++ b/timepiece/templates/timepiece/time-sheet/reports/general_ledger.html
@@ -8,14 +8,14 @@
     <div class="row">
         <div class="span12">
             <h2>Reports</h2>
-            <ul class="unstyled subnav">
+            <ul class="nav nav-pills">
                 <li>
                     {% if perms.timepiece.view_entry_summary %}
                         <a href="{% url hourly_report %}">Hourly</a>
                     {% endif %}
                 </li>
-                <li>
-                    General Ledger
+                <li class="active">
+                    <a href="#">General Ledger</a>
                 </li>
                 <li>
                     {% if perms.timepiece.view_payroll_summary %}

--- a/timepiece/templates/timepiece/time-sheet/reports/hourly.html
+++ b/timepiece/templates/timepiece/time-sheet/reports/hourly.html
@@ -15,9 +15,9 @@
     <div class="row">
         <div class="span12">
             <h2>Reports</h2>
-            <ul class="unstyled subnav">
-                <li>
-                    Hourly
+            <ul class="nav nav-pills">
+                <li class="active">
+                    <a href="#">Hourly</a>
                 </li>
                 <li>
                     {% if perms.timepiece.view_entry_summary %}

--- a/timepiece/templates/timepiece/time-sheet/reports/summary.html
+++ b/timepiece/templates/timepiece/time-sheet/reports/summary.html
@@ -9,7 +9,7 @@
     <div class="row">
         <div class="span12">
             <h2>Reports</h2>
-            <ul class="unstyled subnav">
+            <ul class="nav nav-pills">
                 <li>
                     {% if perms.timepiece.view_entry_summary %}
                         <a href='{% url 'hourly_report' %}'>Hourly</a>
@@ -20,8 +20,8 @@
                         <a href='{% url 'timepiece-summary' %}'>General Ledger</a>
                     {% endif %}
                 </li>
-                <li>
-                    Payroll Report
+                <li class="active">
+                    <a href="#">Payroll Report</a>
                 </li>
             </ul>
         </div>


### PR DESCRIPTION
The subnav now uses the navigation pills provided by Bootstrap

See #280 for details.
