### PR TITLE
refs #283, #286 - Payroll upgrade

### DIFF
--- a/timepiece/templates/timepiece/time-sheet/reports/summary.html
+++ b/timepiece/templates/timepiece/time-sheet/reports/summary.html
@@ -61,7 +61,7 @@
     </div>
 
     <div class="row">
-        <div class="span8">
+        <div class="span12">
             <h3>Hourly Summary</h3>
             {% if monthly_totals %}
                 <table class="table table-bordered table-striped table-condensed">
@@ -98,8 +98,10 @@
                 <p> No entries found.</p>
             {% endif %}
         </div>
+    </div>
 
-        <div class="span4">
+    <div class="row">
+        <div class="span12">
             <h3>Weekly Summary</h3>
             {% if weekly_totals.0.0 %}
                 <table class='table table-striped table-bordered table-condensed'>


### PR DESCRIPTION
Upgraded the payroll summary template. There are no longer any static calendars and the two tables have been moved into a single column.

See #283 and #286 for details.
