### PR TITLE
refs #288 - Buttons redirect to dashboard

### DIFF
--- a/timepiece/templates/timepiece/time-sheet/entry/add_update_entry.html
+++ b/timepiece/templates/timepiece/time-sheet/entry/add_update_entry.html
@@ -15,7 +15,7 @@
                 {{ form|as_bootstrap:"horizontal" }}
                 <div class="form-actions">
                     <input class="btn btn-primary" type='submit' name='submit' value='Save' />
-                    <input class="btn" type='button' value='Cancel' onclick='history.go(-1)' />
+                    <input class="btn" type='button' value='Cancel' onclick="window.location='{% url timepiece-entries %}'" />
                 </div>
             </form>
         </div>

--- a/timepiece/templates/timepiece/time-sheet/entry/clock_in.html
+++ b/timepiece/templates/timepiece/time-sheet/entry/clock_in.html
@@ -1,7 +1,9 @@
 {% extends 'timepiece/time-sheet/base.html' %}
 {% load timepiece_tags %}
-{% block title %}Clock In{% endblock %}
 {% load bootstrap_toolkit %}
+
+{% block title %}Clock In{% endblock %}
+
 
 {% block content %}
     <div class="row">
@@ -23,7 +25,7 @@
                 {{ form|as_bootstrap:"horizontal" }}
                 <div class="form-actions">
                     <input class="btn btn-primary" type="submit" name="submit" value="Clock In" />
-                    <input class="btn" type="button" value="Cancel" onclick="history.go(-1)" />
+                    <input class="btn cancel" type="button" value="Cancel" onclick="window.location='{% url timepiece-entries %}'" />
                 </div>
             </form>
         </div>

--- a/timepiece/templates/timepiece/time-sheet/entry/clock_out.html
+++ b/timepiece/templates/timepiece/time-sheet/entry/clock_out.html
@@ -13,7 +13,7 @@
                 {{ form|as_bootstrap:"horizontal" }}
                 <div class="form-actions">
                     <input class="btn btn-primary" type="submit" name="submit" value="Clock Out" />
-                    <input class="btn" type="button" value="Cancel" onclick="history.go(-1)" />
+                    <input class="btn" type="button" value="Cancel" onclick="window.location='{% url timepiece-entries %}'" />
                 </div>
             </form>
         </div>

--- a/timepiece/templates/timepiece/time-sheet/entry/delete_entry.html
+++ b/timepiece/templates/timepiece/time-sheet/entry/delete_entry.html
@@ -15,7 +15,7 @@
                 <input type="hidden" name="key" value="{{ entry.delete_key }}" />
                 <div class="form-actions">
                     <input class="btn btn-primary" type="submit" value="Yes" />
-                    <input class="btn" type="button" value="No" onclick="javascript:history.go(-1)" />
+                    <input class="btn" type="button" value="No" onclick="window.location='{% url timepiece-entries %}'" />
                 </div>
             </form>
         </div>


### PR DESCRIPTION
Buttons now redirect back to the dashboard. The reject entry button was not changed since it would no make sense to redirect back to the dashboard. Its current behavior goes back to the ledger, which makes the most sense.

See #288 for details.
