### PR TITLE
refs #281 - Update to form enables user switching

### DIFF
--- a/timepiece/templates/timepiece/time-sheet/people/view.html
+++ b/timepiece/templates/timepiece/time-sheet/people/view.html
@@ -1,5 +1,6 @@
 {% extends "timepiece/time-sheet/base.html" %}
 {% load timepiece_tags %}
+{% load bootstrap_toolkit %}
 {% load url from future %}
 
 {% block extrajs %}
@@ -44,8 +45,8 @@
     <div class="row">
         <div class="span12">
             <form class="form-inline" method="get" action="" accept-charset="utf-8">
-                {{ year_month_form }}
-                <button type="submit" class="btn">Update</button>
+                {{ year_month_form|as_bootstrap:"inline" }}
+                <input type="submit" name="yearmonth" class="btn" value="Update" />
             </form>
         </div class="span12">
     </div>


### PR DESCRIPTION
The form was missing a value needed to be present to redirect (the button's value). It checks for it in the get request before redirecting. Re-added the value.

See #281 for more details.
