### PR TITLE
refs #337 - Created separate mobile form

### DIFF
--- a/timepiece/templates/timepiece/time-sheet/people/view.html
+++ b/timepiece/templates/timepiece/time-sheet/people/view.html
@@ -54,7 +54,7 @@
                 {{ year_month_form|as_bootstrap:"inline" }}
                 <input type="submit" name="yearmonth" class="btn" value="Update" />
             </form>
-            <form class="hidden-desktop"method="get" action="" accept-charset="utf-8">
+            <form class="hidden-desktop" method="get" action="" accept-charset="utf-8">
                 {{ year_month_form|as_bootstrap }}
                 <input type="submit" name="yearmonth" class="btn" value="Update" />
             </form>


### PR DESCRIPTION
The form contained two sets of the same elements. One set was hidden, though, using Bootstrap's responsive feature. I just moved the mobile form into its own `<form>` element and show/hide the forms instead of the divs containing the forms.
