### PR TITLE
refs #352, #353 - Responsive updates

### DIFF
--- a/timepiece/static/timepiece/less/style.less
+++ b/timepiece/static/timepiece/less/style.less
@@ -372,7 +372,7 @@ body {
 
         #full-timesheet {
             width: 100%;
-            min-width: 700px;
+            min-width: 800px;
 
             table {
                 width: 100%;
@@ -396,6 +396,10 @@ body {
                     }
 
                     &.project {
+                        width: 13%;
+                    }
+
+                    &.activity {
                         width: 15%;
                     }
                 }

--- a/timepiece/templates/timepiece/time-sheet/people/view.html
+++ b/timepiece/templates/timepiece/time-sheet/people/view.html
@@ -138,8 +138,8 @@
                                     <thead>
                                         <tr>
                                             <th>Date</th>
-                                            <th>Project</th>
-                                            <th>Activity</th>
+                                            <th class="project">Project</th>
+                                            <th class="activity">Activity</th>
                                             <th>Location</th>
                                             <th class="time">Time In</th>
                                             <th class="time">Time Out</th>
@@ -161,7 +161,7 @@
                                 <td></td>
                                 {% endifchanged %}
                                 <td class="project">{{ entry.project__name }}</td>
-                                <td class="break">{{ entry.activity__name }}</td>
+                                <td class="activity">{{ entry.activity__name }}</td>
                                 <td>{{ entry.location__name }}</td>
                                 <td class="time break">{{ entry.start_time|date:"P" }}</td>
                                 <td class="time break">{{ entry.end_time|date:"P" }}</td>


### PR DESCRIPTION
Updated the margin between the navbar and the breadcrumb and increased the left and right padding on pages.

The full timesheet table no longer breaks project names in weird places, but at lower resolutions, the project names will still break, but at readable spots (hyphens, spaces, etc.).

Note: The table could be made a larger width to accommodate the lower resolution devices. Let me know if we should do this.
