### PR TITLE
refs #390 - Cannot add entries after timesheet approval

### DIFF
--- a/timepiece/models.py
+++ b/timepiece/models.py
@@ -539,7 +539,7 @@ class Entry(models.Model):
         )
         if entries.exists():
             msg = 'You cannot add entries after a timesheet has been ' \
-                'approved. Please correct the start and end times.'
+                'approved or invoiced. Please correct the start and end times.'
             raise ValidationError(msg)
         return True
 


### PR DESCRIPTION
You can no longer add entries for a month after your timesheet has been approved for that month.

See #390 for details.
