### PR TITLE
Fix example project

### DIFF
--- a/example_project/manage.py
+++ b/example_project/manage.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 if __name__ == "__main__":
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "example_project.settings")
 
     from django.core.management import execute_from_command_line
 

--- a/example_project/settings.py
+++ b/example_project/settings.py
@@ -112,10 +112,10 @@ TEMPLATE_CONTEXT_PROCESSORS = (
     'django.core.context_processors.request',
 )
 
-ROOT_URLCONF = 'urls'
+ROOT_URLCONF = 'example_project.urls'
 
 # Python dotted path to the WSGI application used by Django's runserver.
-WSGI_APPLICATION = 'wsgi.application'
+WSGI_APPLICATION = 'example_project.wsgi.application'
 
 TEMPLATE_DIRS = (
     '%s/templates' % PROJECT_PATH,

--- a/example_project/wsgi.py
+++ b/example_project/wsgi.py
@@ -15,7 +15,7 @@ framework.
 """
 import os
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "example_project.settings")
 
 # This application object is used by any WSGI server configured to use this
 # file. This includes Django's development server, if the WSGI_APPLICATION


### PR DESCRIPTION
The minimum changes required to make the example project work. Corrected references in wsgi.py, settings.py, and manage.py to remove "example_project.". Added "selectable" to INSTALLED_APPS and added the django-selectable javascript to the django-timepiece base template to enable selectable inputs.
