### PR TITLE
Made negative hours return with (time) rather than -time.

### DIFF
--- a/timepiece/static/timepiece/less/style.less
+++ b/timepiece/static/timepiece/less/style.less
@@ -376,12 +376,6 @@ body {
                 margin-bottom: 10px;
             }
         }
-        #project-progress {
-            .overtime {
-                color: @red;
-                font-weight: bold;
-            }
-        }
     }
 
     &#paste {

--- a/timepiece/templates/timepiece/time-sheet/dashboard.html
+++ b/timepiece/templates/timepiece/time-sheet/dashboard.html
@@ -76,10 +76,10 @@
                             {% for project in project_progress %}
                                 <tr>
                                     <td><a href="{% url 'timepiece-clock-in' %}?project={{ project.pk }}">{{ project.name }}</a></td>
-                                    <td>{{ project.worked|humanize_hours|slice:":-3" }}</td>
-                                    <td>{{ project.assigned|humanize_hours|slice:":-3" }}</td>
-                                    <td{% if project.remaining < 0 %} class="overtime"{% endif %}>
-                                        {{ project.remaining|humanize_hours|slice:":-3" }}
+                                    <td>{{ project.worked|convert_hours_to_seconds|humanize_seconds:"%H:%M" }}</td>
+                                    <td>{{ project.assigned|convert_hours_to_seconds|humanize_seconds:"%H:%M" }}</td>
+                                    <td>
+                                        {{ project.remaining|convert_hours_to_seconds|humanize_seconds:"%H:%M" }}
                                     </td>
                                     <td class="project_progress_bar"
                                         data-worked = "{{ project.worked }}"

--- a/timepiece/templatetags/timepiece_tags.py
+++ b/timepiece/templatetags/timepiece_tags.py
@@ -104,23 +104,32 @@ def get_uninvoiced_hours(entries):
 
 
 @register.filter
-def humanize_hours(total_hours):
+def convert_hours_to_seconds(total_hours):
     """Given time in Decimal(hours), return a unicode in %H:%M:%S format."""
-    return humanize_seconds(float(total_hours) * 3600)
+    return int(float(total_hours) * 3600)
 
 
 @register.filter
-def humanize_seconds(total_seconds):
+def humanize_seconds(total_seconds, format='%H:%M:%S'):
     """Given time in int(seconds), return a unicode in %H:%M:%S format."""
     seconds = abs(int(total_seconds))
     hours = seconds // 3600
     seconds %= 3600
     minutes = seconds // 60
     seconds %= 60
-    prefix = u'-' if total_seconds < 0 else u''
-    return prefix + u':'.join([
-        u'{0:02d}'.format(time_unit) for time_unit in (hours, minutes, seconds)
+    format_mapping = {
+        '%H': hours,
+        '%M': minutes,
+        '%S': seconds,
+    }
+    time_units = [
+        format_mapping[token] for token in format.split(':')
+        if token in format_mapping
+    ]
+    result = ':'.join([
+        u'{0:02d}'.format(time_unit) for time_unit in time_units
     ])
+    return result if total_seconds >= 0 else '({0})'.format(result)
 
 
 @register.filter

--- a/timepiece/tests/template_tags.py
+++ b/timepiece/tests/template_tags.py
@@ -12,8 +12,8 @@ class HumanizeSecondsTestCase(TimepieceDataTestCase):
 
     def test_negative_seconds(self):
         seconds_display = tags.humanize_seconds((-2.5 * 3600) - 4)
-        self.assertEqual(seconds_display, u'-02:30:04',
-            "Should return u'-02:30:04', returned {0}".format(seconds_display)
+        self.assertEqual(seconds_display, u'(02:30:04)',
+            "Should return u'(02:30:04)', returned {0}".format(seconds_display)
         )
 
     def test_overnight(self):
@@ -22,26 +22,28 @@ class HumanizeSecondsTestCase(TimepieceDataTestCase):
             "Should return u'30:00:02', returned {0}".format(seconds_display)
         )
 
+    def test_format(self):
+        seconds_display = tags.humanize_seconds(120, '%M:%M:%M')
+        expected = u'02:02:02'
+        self.assertEqual(seconds_display, expected,
+            "Should return {0}, return {1}".format(expected, seconds_display)
+        )
 
-class HumanizeHoursTestCase(TimepieceDataTestCase):
+
+class ConvertHoursToSecondsTestCase(TimepieceDataTestCase):
 
     def test_usual(self):
-        hours_display = tags.humanize_hours('3.25')
-        self.assertEqual(hours_display, u'03:15:00',
-            "Given 3.25 hours, returned {0}, expected u'03:15:00'".format(
-                hours_display)
+        seconds = tags.convert_hours_to_seconds('3.25')
+        expected = int(3.25 * 3600)
+        self.assertEqual(seconds, expected,
+            "Given 3.25 hours, returned {0}, expected {1}".format(
+                seconds, expected)
         )
 
     def test_negative_seconds(self):
-        hours_display = tags.humanize_hours('-2.75')
-        self.assertEqual(hours_display, u'-02:45:00',
-            "Given -2.75 hours, returned {0}, expected u'-02:45:00'".format(
-                hours_display)
-        )
-
-    def test_overnight(self):
-        hours_display = tags.humanize_hours('25.5')
-        self.assertEqual(hours_display, u'25:30:00',
-            "Given 25.5 hours, returned {0}, expected u'25:30:00'".format(
-                hours_display)
+        seconds = tags.convert_hours_to_seconds('-2.75')
+        expected = int(-2.75 * 3600)
+        self.assertEqual(seconds, expected,
+            "Given -2.75 hours, returned {0}, expected {1}".format(
+                seconds, expected)
         )


### PR DESCRIPTION
Refs #535

This required some implementation changes with how we're handling string formatting of times.

I think humanize seconds is very generalized now, but that we can/should eventually remove convert_to_seconds as discussed IRL
