### PR TITLE
Remove dependency on PostgreSQL's DATE_TRUNC to allow other db backends.

### DIFF
--- a/timepiece/models.py
+++ b/timepiece/models.py
@@ -7,6 +7,7 @@ from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import Q, Sum, Max, Min
+from django.db import connection
 
 try:
     from django.utils import timezone
@@ -276,9 +277,9 @@ class EntryQuerySet(models.query.QuerySet):
     """QuerySet extension to provide filtering by billable status"""
 
     def date_trunc(self, key='month', extra_values=None):
-        select = {"day": {"date": """DATE_TRUNC('day', end_time)"""},
-                  "week": {"date": """DATE_TRUNC('week', end_time)"""},
-                  "month": {"date": """DATE_TRUNC('month', end_time)"""},
+        select = {"day" : {"date" : connection.ops.date_trunc_sql('day', 'end_time')},
+                  "week" : {"date" : connection.ops.date_trunc_sql('week', 'end_time')},
+                  "month" : {"date" : connection.ops.date_trunc_sql('month', 'end_time')},
         }
         basic_values = (
             'user', 'date', 'user__first_name', 'user__last_name', 'billable',

--- a/timepiece/utils.py
+++ b/timepiece/utils.py
@@ -7,6 +7,7 @@ from itertools import groupby
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.db.models import Sum, get_model, Q
+from django.db import connection
 from django.template.defaultfilters import slugify
 from django.utils.functional import lazy
 
@@ -164,8 +165,8 @@ def daily_summary(day_entries):
 
 
 def grouped_totals(entries):
-    select = {"day": {"date": """DATE_TRUNC('day', end_time)"""},
-              "week": {"date": """DATE_TRUNC('week', end_time)"""}}
+    select = {"day" : {"date" : connection.ops.date_trunc_sql('day', 'end_time')},
+              "week" : {"date" : connection.ops.date_trunc_sql('week', 'end_time')}}
     weekly = entries.extra(select=select["week"]).values('date', 'billable')
     weekly = weekly.annotate(hours=Sum('hours')).order_by('date')
     daily = entries.extra(select=select["day"]).values('date', 'project__name',


### PR DESCRIPTION
Hi there,

Just been playing around with the example_project using the sqlite3 backend (not having a PostgreSQL server installed). All I did was to remove the hard coded DATE_TRUNC sql strings and use django.db.connection.ops.date_trunc_sql. There is no much documentation on this in the django docs, but this interface seems to have been around since at least Django 1.0.

With these changes the sqlite3 backend works quite nicely for me. I've encountered no problems so far, but since I'm not an experienced user (yet) I could have missed some other dependency on PostgreSQL. As date_trunc_sql is provided by django itself, it also should allow to use of the MySQL backend (untested).

On the PostrgeSQL backend nothing should change (untested!), as date_trunc_sql is just a thin wrapper in that case:
https://github.com/django/django/blob/master/django/db/backends/postgresql_psycopg2/operations.py#L37

Maybe this helps!
