### PR TITLE
Clicking 'Clock Out' more than once gives 404 error

### DIFF
--- a/timepiece/tests/tracking/timesheet.py
+++ b/timepiece/tests/tracking/timesheet.py
@@ -730,6 +730,31 @@ class ClockOutTest(TimepieceDataTestCase):
             '%(project)s - %(activity)s - from %(st_str)s to %(end_str)s' %
             entry1_data)
 
+    def test_clocking_out_inactive(self):
+        # If clock out when not active, redirect to dashboard
+        # (e.g. double-clicked clock out button or clicked it on an old page)
+
+        # setUp clocked us in, so clock out again
+        data = {
+            'start_time_0': self.entry.start_time.strftime('%m/%d/%Y'),
+            'start_time_1': self.entry.start_time.strftime('%H:%M:%S'),
+            'end_time_0': self.default_end_time.strftime('%m/%d/%Y'),
+            'end_time_1': self.default_end_time.strftime('%H:%M:%S'),
+            'location': self.location.pk,
+            }
+        response = self.client.post(
+            self.url, data,
+            follow=True,
+            )
+        # Do it again - make sure we redirect to the dashboard
+        response = self.client.post(
+            self.url, data,
+            follow=False,
+            )
+        self.assertRedirects(response, reverse('dashboard'),
+                             status_code=302, target_status_code=200)
+
+
 
 class CheckOverlap(TimepieceDataTestCase):
     """

--- a/timepiece/views.py
+++ b/timepiece/views.py
@@ -148,7 +148,9 @@ def clock_in(request):
 def clock_out(request):
     entry = utils.get_active_entry(request.user)
     if not entry:
-        raise Http404
+        message = "Not clocked in"
+        messages.info(request, message)
+        return HttpResponseRedirect(reverse('dashboard'))
     if request.POST:
         form = timepiece_forms.ClockOutForm(request.POST, instance=entry)
         if form.is_valid():


### PR DESCRIPTION
This happens because there is no active entry to clock out, so the code raises a 404. Since most users will only come across this issue after clicking on the 'Clock Out' button more than once, it would be better user experience to redirect the user to the dashboard.
