### PR TITLE
Comments appear to cut off on "All entries" dashboard tab

### DIFF
--- a/timepiece/templates/timepiece/dashboard.html
+++ b/timepiece/templates/timepiece/dashboard.html
@@ -171,7 +171,13 @@
                                             {% endwith %}
                                         </td>
                                         <td class="nowrap">{{ entry.get_total_seconds|humanize_seconds|slice:":-3" }}</td>
-                                        <td class="hidden-phone">{{ entry.comments|slice:':50' }}</td>
+                                        <td class="hidden-phone">
+                                            {% if entry.comments|length > 50 %}
+                                                {{entry.comments|slice:':50'}}&hellip;
+                                            {% else %}
+                                                {{ entry.comments }}
+                                            {% endif %}
+                                        </td>
                                     </tr>
                                 {% endfor %}
                                 {% sum_hours day.list 'daily_total' %}


### PR DESCRIPTION
Since only 50 (or so) characters are displayed and no ellipses are used, the comment appears to cut off.
