### PR TITLE
Drop Django 1.3 support

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -4,7 +4,7 @@ import sys
 import optparse
 
 from django.conf import settings
-from django.core.management import call_command, setup_environ
+from django.core.management import call_command
 
 
 parser = optparse.OptionParser()

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,10 @@
 [tox]
 envlist =
-    py26-1.3, py26-1.4,
-    py27-1.3, py27-1.4,
+    py26-1.4, py26-1.5,
+    py27-1.4, py27-1.5
+
+# Note: sadly, we're not yet compatible with Django trunk/1.6-to-be.
+# Test environments for trunk are defined below, but not included in this list.
 
 [default]
 deps =
@@ -16,21 +19,12 @@ deps =
 [testenv]
 basepython = python2.7
 deps =
-    django==1.3.1
+    django==1.4.3
     {[default]deps}
 setenv =
     DJANGO_SETTINGS_MODULE = example_project.example_project.settings.local
     PYTHON_PATH = {toxinidir}
 commands = {envpython} run_tests.py {posargs}
-
-[testenv:py26-1.3]
-basepython = python2.6
-setenv =
-    {[testenv]setenv}
-    TESTENV = py26-1.3
-deps =
-    django>=1.3,<1.4
-    {[default]deps}
 
 [testenv:py26-1.4]
 basepython = python2.6
@@ -47,21 +41,21 @@ setenv =
     {[testenv]setenv}
     TESTENV = py26-1.5
 deps =
-    https://github.com/django/django/archive/1.5b2.zip
+    django>=1.5,<1.6
     {[default]deps}
 
-[testenv:py27-1.3]
+[testenv:py26-trunk]
+basepython = python2.6
 setenv =
     {[testenv]setenv}
-    TESTENV= py27-1.3
-deps =
-    django>=1.3,<1.4
+    TESTENV = py26-trunk
+deps = https://github.com/django/django/zipball/master
     {[default]deps}
 
 [testenv:py27-1.4]
 setenv =
     {[testenv]setenv}
-    TESTENV = py27-1.4
+    TESTENV= py27-1.4
 deps =
     django>=1.4,<1.5
     {[default]deps}
@@ -71,5 +65,12 @@ setenv =
     {[testenv]setenv}
     TESTENV = py27-1.5
 deps =
-    https://github.com/django/django/archive/1.5b2.zip
+    django>=1.5,<1.6
+    {[default]deps}
+
+[testenv:py27-trunk]
+setenv =
+    {[testenv]setenv}
+    TESTENV = py27-trunk
+deps = https://github.com/django/django/zipball/master
     {[default]deps}


### PR DESCRIPTION
We should make a plan for dropping Django 1.3 support, especially with Django 1.5 coming out soon.
