### PR TITLE
refactored navbar templates

### DIFF
--- a/timepiece/templates/timepiece/navigation-crm.html
+++ b/timepiece/templates/timepiece/navigation-crm.html
@@ -1,0 +1,23 @@
+{% load timepiece_tags %}
+{% load url from future %}
+
+{# FIXME: Some permissions don't exist #}
+{% if perms.crm.view_project or perms.auth.view_user or perms.crm.view_business or perms.contracts.add_project_contract %}
+    <li class="dropdown">
+        <a href="#" class="dropdown-toggle" data-toggle="dropdown">CRM <b class="caret"></b></a>
+        <ul class="dropdown-menu">
+            {% if perms.crm.view_project %}
+                <li><a href="{% url 'list_projects' %}">Projects</a></li>
+            {% endif %}
+            {% if perms.auth.view_user %}  {# FIXME: Permission doesn't exist #}
+                <li><a href="{% url 'list_users' %}">Users</a></li>
+            {% endif %}
+            {% if perms.crm.view_business %}  {# FIXME: Permission doesn't exist #}
+                <li><a href="{% url 'list_businesses' %}">Businesses</a></li>
+            {% endif %}
+            {% if perms.contracts.add_project_contract %}
+                <li><a href="{% url 'list_contracts' %}">Contracts</a></li>
+            {% endif %}
+        </ul>
+    </li>
+{% endif %}

--- a/timepiece/templates/timepiece/navigation-management.html
+++ b/timepiece/templates/timepiece/navigation-management.html
@@ -1,0 +1,31 @@
+{% load timepiece_tags %}
+{% load url from future %}
+
+{# FIXME: Some of those permissions don't exist #}
+{% if perms.entries.can_clock_in or perms.entries.view_entry_summary or perms.entries.view_payroll_summary or perms.contracts.change_entrygroup or user.is_staff %}
+    <li class="dropdown">
+        <a href="#" class="dropdown-toggle" data-toggle="dropdown">Management <b class="caret"></b></a>
+        <ul class="dropdown-menu">
+            {% if perms.entries.view_entry_summary %}  {# FIXME: permission doesn't exist #}
+                <li><a href="{% url 'report_billable_hours' %}">Billable Hours</a></li>
+                <li><a href="{% url 'report_hourly' %}">Hourly</a></li>
+            {% endif %}
+            {% if perms.entries.view_payroll_summary %}
+                <li><a href="{% url 'report_payroll_summary' %}">Payroll Summary</a></li>
+                <li><a href="{% url 'report_productivity' %}">Productivity</a></li>
+                {% if user.is_staff or perms.contracts.change_entrygroup or perms.entries.can_clock_in %}
+                    <li class="divider"></li>
+                {% endif %}
+            {% endif %}
+            {% if user.is_staff %}
+                <li><a href="{% url 'admin:index' %}">Admin</a></li>
+            {% endif %}
+            {% if perms.contracts.change_entrygroup %}
+                <li><a href="{% url 'list_outstanding_invoices' %}">Invoices</a></li>
+            {% endif %}
+            {% if perms.entries.can_clock_in %}
+                <li><a href="{% url 'view_schedule' %}">Weekly Schedule</a></li>
+            {% endif %}
+        </ul>
+    </li>
+{% endif %}

--- a/timepiece/templates/timepiece/navigation-quick-clock-in.html
+++ b/timepiece/templates/timepiece/navigation-quick-clock-in.html
@@ -1,0 +1,21 @@
+{% load timepiece_tags %}
+{% load url from future %}
+{% block quick-clock-in %}
+    {% if perms.entries.can_clock_in %}
+        <li class="dropdown">
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown"><i class="icon-time icon-white"> </i><b class="caret"></b> </a>
+            <ul class="dropdown-menu">
+                <li><a href="{% url 'clock_in' %}">Clock in...</a></li>
+                <li><a href="{% url 'create_entry' %}">Add Entry...</a></li>
+                {% if work_projects %}<li class="divider"></li>{% endif %}
+                {% for project in work_projects %}
+                    <li><a href="{% url 'clock_in' %}?project={{ project.id }}">{{ project }}</a></li>
+                {% endfor %}
+                {% if leave_projects %}<li class="divider"></li>{% endif %}
+                {% for project in leave_projects %}
+                    <li><a href="{% url 'clock_in' %}?project={{ project.id }}">{{ project }}</a></li>
+                {% endfor %}
+            </ul>
+        </li>
+    {% endif %}
+{% endblock quick-clock-in %}

--- a/timepiece/templates/timepiece/navigation-timesheet.html
+++ b/timepiece/templates/timepiece/navigation-timesheet.html
@@ -1,0 +1,6 @@
+{% load timepiece_tags %}
+{% load url from future %}
+
+{% if perms.entries.add_entry %}
+    <li><a href="{% url 'view_user_timesheet' request.user.pk %}">Time Sheet</a></li>
+{% endif %}

--- a/timepiece/templates/timepiece/navigation.html
+++ b/timepiece/templates/timepiece/navigation.html
@@ -8,79 +8,10 @@
             {% block navbar-left %}
                 <a class="brand" href="/">Timepiece</a>
                 <ul class="nav pull-left">
-                    {% block quick-clock-in %}
-                        {% if perms.entries.can_clock_in %}
-                            <li class="dropdown">
-                                <a href="#" class="dropdown-toggle" data-toggle="dropdown"><i class="icon-time icon-white"> </i><b class="caret"></b> </a>
-                                <ul class="dropdown-menu">
-                                    <li><a href="{% url 'clock_in' %}">Clock in...</a></li>
-                                    <li><a href="{% url 'create_entry' %}">Add Entry...</a></li>
-                                    {% if work_projects %}<li class="divider"></li>{% endif %}
-                                    {% for project in work_projects %}
-                                        <li><a href="{% url 'clock_in' %}?project={{ project.id }}">{{ project }}</a></li>
-                                    {% endfor %}
-                                    {% if leave_projects %}<li class="divider"></li>{% endif %}
-                                    {% for project in leave_projects %}
-                                        <li><a href="{% url 'clock_in' %}?project={{ project.id }}">{{ project }}</a></li>
-                                    {% endfor %}
-                                </ul>
-                            </li>
-                        {% endif %}
-                    {% endblock quick-clock-in %}
-
-                    {% if perms.entries.add_entry %}
-                        <li><a href="{% url 'view_user_timesheet' request.user.pk %}">Time Sheet</a></li>
-                    {% endif %}
-
-                    {# FIXME: Some permissions don't exist #}
-                    {% if perms.crm.view_project or perms.auth.view_user or perms.crm.view_business or perms.contracts.add_project_contract %}
-                        <li class="dropdown">
-                            <a href="#" class="dropdown-toggle" data-toggle="dropdown">CRM <b class="caret"></b></a>
-                            <ul class="dropdown-menu">
-                                {% if perms.crm.view_project %}
-                                    <li><a href="{% url 'list_projects' %}">Projects</a></li>
-                                {% endif %}
-                                {% if perms.auth.view_user %}  {# FIXME: Permission doesn't exist #}
-                                    <li><a href="{% url 'list_users' %}">Users</a></li>
-                                {% endif %}
-                                {% if perms.crm.view_business %}  {# FIXME: Permission doesn't exist #}
-                                    <li><a href="{% url 'list_businesses' %}">Businesses</a></li>
-                                {% endif %}
-                                {% if perms.contracts.add_project_contract %}
-                                    <li><a href="{% url 'list_contracts' %}">Contracts</a></li>
-                                {% endif %}
-                            </ul>
-                        </li>
-                    {% endif %}
-
-                    {# FIXME: Some of those permissions don't exist #}
-                    {% if perms.entries.can_clock_in or perms.entries.view_entry_summary or perms.entries.view_payroll_summary or perms.contracts.change_entrygroup or user.is_staff %}
-                        <li class="dropdown">
-                            <a href="#" class="dropdown-toggle" data-toggle="dropdown">Management <b class="caret"></b></a>
-                            <ul class="dropdown-menu">
-                                {% if perms.entries.view_entry_summary %}  {# FIXME: permission doesn't exist #}
-                                    <li><a href="{% url 'report_billable_hours' %}">Billable Hours</a></li>
-                                    <li><a href="{% url 'report_hourly' %}">Hourly</a></li>
-                                {% endif %}
-                                {% if perms.entries.view_payroll_summary %}
-                                    <li><a href="{% url 'report_payroll_summary' %}">Payroll Summary</a></li>
-                                    <li><a href="{% url 'report_productivity' %}">Productivity</a></li>
-                                    {% if user.is_staff or perms.contracts.change_entrygroup or perms.entries.can_clock_in %}
-                                        <li class="divider"></li>
-                                    {% endif %}
-                                {% endif %}
-                                {% if user.is_staff %}
-                                    <li><a href="{% url 'admin:index' %}">Admin</a></li>
-                                {% endif %}
-                                {% if perms.contracts.change_entrygroup %}
-                                    <li><a href="{% url 'list_outstanding_invoices' %}">Invoices</a></li>
-                                {% endif %}
-                                {% if perms.entries.can_clock_in %}
-                                    <li><a href="{% url 'view_schedule' %}">Weekly Schedule</a></li>
-                                {% endif %}
-                            </ul>
-                        </li>
-                    {% endif %}
+                    {% include "timepiece/navigation-quick-clock-in.html" %}
+                    {% include "timepiece/navigation-timesheet.html" %}
+                    {% include "timepiece/navigation-crm.html" %}
+                    {% include "timepiece/navigation-management.html" %}
 
                     {% include "timepiece/extra_nav.html" %}
                 </ul>


### PR DESCRIPTION
Refactored navigation template into different pieces.  Although the extranav template was available, that seems more appropriate for projects where timepiece is the primary as opposed to timepiece being a secondary app.
I'm looking at timepiece being a secondary app along with other django projects, so taking this approach allows for using a different parent navbar that brings in the timepiece components.
