### PR TITLE
Fixes failing unittests for hourly report and templatetags

### DIFF
--- a/timepiece/reports/tests/test_hourly.py
+++ b/timepiece/reports/tests/test_hourly.py
@@ -157,8 +157,8 @@ class TestHourlyReport(ViewTestMixin, LogTimeMixin, ReportsTestBase):
         end = utils.add_timezone(
                 kwargs.pop('end', datetime.datetime(2011, 1, 4)))
         defaults = {
-            'from_date': start.strftime('%m/%d/%Y'),
-            'to_date': end.strftime('%m/%d/%Y'),
+            'from_date': start.strftime('%Y-%m-%d'),
+            'to_date': end.strftime('%Y-%m-%d'),
             'export': True,
             'billable': True,
             'non_billable': True,

--- a/timepiece/templatetags/timepiece_tags.py
+++ b/timepiece/templatetags/timepiece_tags.py
@@ -179,9 +179,8 @@ def project_hours_for_contract(contract, project, billable=None):
     return hours
 
 
-@register.simple_tag
-def project_report_url_for_contract(contract, project):
-    data = {
+def _project_report_url_params(contract, project):
+    return {
         'from_date': contract.start_date.strftime(DATE_FORM_FORMAT),
         'to_date': contract.end_date.strftime(DATE_FORM_FORMAT),
         'billable': 1,
@@ -190,6 +189,11 @@ def project_report_url_for_contract(contract, project):
         'trunc': 'month',
         'projects_1': project.id,
     }
+
+
+@register.simple_tag
+def project_report_url_for_contract(contract, project):
+    data = _project_report_url_params(contract, project)
     return '{0}?{1}'.format(reverse('report_hourly'), urllib.urlencode(data))
 
 

--- a/timepiece/tests/test_templatetags.py
+++ b/timepiece/tests/test_templatetags.py
@@ -164,18 +164,20 @@ class MiscTagTestCase(TestCase):
         self.assertEqual(49, retval)
 
     def test_project_report_url_for_contract(self):
-        with mock.patch('timepiece.templatetags.timepiece_tags.reverse')\
-        as reverse:
-            reverse.return_value = "Boo"
-            dt = datetime.date(2013, 1, 10)
-            contract = mock.Mock(start_date=dt, end_date=dt)
-            project = mock.Mock(id=54)
-            retval = tags.project_report_url_for_contract(contract, project)
-            url = 'Boo?billable=1&projects_1=54&from_date=' \
-                '2013-01-10&to_date=2013-01-10&non_billable=0' \
-                '&paid_leave=0&trunc=month'
-            self.assertEqual(url, retval)
-            self.assertEqual('report_hourly', reverse.call_args[0][0])
+        dt = datetime.date(2013, 1, 10)
+        contract = mock.Mock(start_date=dt, end_date=dt)
+        project = mock.Mock(id=54)
+        result = tags._project_report_url_params(contract, project)
+        expected_url = {
+            'from_date': '2013-01-10',
+            'to_date': '2013-01-10',
+            'billable': 1,
+            'non_billable': 0,
+            'paid_leave': 0,
+            'trunc': 'month',
+            'projects_1': project.id,
+        }
+        self.assertEqual(expected_url, result)
 
 
 class SumHoursTagTestCase(TestCase):


### PR DESCRIPTION
The hourly report failures stemmed from a change in expected date format.

The templatetag was returning a correct urlencoded string in a different order than the test.
