### PR TITLE
Fixes hourly report CSV unit tests and export

### DIFF
--- a/timepiece/reports/tests/test_hourly.py
+++ b/timepiece/reports/tests/test_hourly.py
@@ -159,7 +159,7 @@ class TestHourlyReport(ViewTestMixin, LogTimeMixin, ReportsTestBase):
         defaults = {
             'from_date': start.strftime('%Y-%m-%d'),
             'to_date': end.strftime('%Y-%m-%d'),
-            'export': True,
+            'export_users': True,
             'billable': True,
             'non_billable': True,
             'paid_leave': True,

--- a/timepiece/reports/views.py
+++ b/timepiece/reports/views.py
@@ -235,7 +235,7 @@ class HourlyReport(ReportMixin, CSVViewMixin, TemplateView):
 
         context.update({
             'date_headers': date_headers,
-            'summaries': summaries,
+            'summaries': dict(summaries),
             'range_headers': range_headers,
         })
         return context


### PR DESCRIPTION
Fills the CSV export with data and fixes failing tests.

The tests were set up to send the 'export' get parameter, but export_users or export_projects is needed to make a CSV export return
