### PR TITLE
Properly aggregate totals per employee in Payroll Report

### DIFF
--- a/timepiece/entries/models.py
+++ b/timepiece/entries/models.py
@@ -79,8 +79,10 @@ class EntryQuerySet(models.query.QuerySet):
         extra_values = extra_values or ()
         qs = self.extra(select=select[key])
         qs = qs.values(*basic_values + extra_values)
-        qs = qs.annotate(hours=Sum('hours')).order_by('user__last_name',
-                                                      'date')
+        qs = qs.annotate(hours=Sum('hours')).order_by(
+            'user__last_name',
+            'user__first_name',
+            'date')
         return qs
 
     def timespan(self, from_date, to_date=None, span=None, current=False):

--- a/timepiece/entries/models.py
+++ b/timepiece/entries/models.py
@@ -82,6 +82,7 @@ class EntryQuerySet(models.query.QuerySet):
         qs = qs.annotate(hours=Sum('hours')).order_by(
             'user__last_name',
             'user__first_name',
+            'user__pk',
             'date')
         return qs
 

--- a/timepiece/reports/tests/test_payroll.py
+++ b/timepiece/reports/tests/test_payroll.py
@@ -121,6 +121,25 @@ class PayrollTest(ViewTestMixin, LogTimeMixin, TestCase):
             '',
         ])
 
+    def testWeeklyTotalsSameFirstLastName(self):
+        """Ensure that the totals are aggregated correctly for users with the
+        same last name and first name
+        """
+        User.objects.all().update(last_name='Smith', first_name='John')
+        self.all_logs(self.user)
+        self.all_logs(self.user2)
+        self.login_user(self.superuser)
+        response = self.client.get(self.url, self.args)
+        weekly_totals = response.context['weekly_totals']
+        self.assertEqual(weekly_totals[0][0][0][2], [
+            Decimal('22.00'),
+            Decimal('11.00'),
+            '',
+            Decimal('11.00'),
+            Decimal('11.00'),
+            '',
+        ])
+
     def testWeeklyOvertimes(self):
         """Date_trunc on week should result in correct overtime totals"""
         dates = self.dates

--- a/timepiece/reports/tests/test_payroll.py
+++ b/timepiece/reports/tests/test_payroll.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 
 from django.conf import settings
 from django.core.urlresolvers import reverse
-from django.contrib.auth.models import Permission
+from django.contrib.auth.models import Permission, User
 from django.test import TestCase
 
 from timepiece import utils
@@ -88,6 +88,25 @@ class PayrollTest(ViewTestMixin, LogTimeMixin, TestCase):
                          1.01)
 
     def testWeeklyTotals(self):
+        self.all_logs(self.user)
+        self.all_logs(self.user2)
+        self.login_user(self.superuser)
+        response = self.client.get(self.url, self.args)
+        weekly_totals = response.context['weekly_totals']
+        self.assertEqual(weekly_totals[0][0][0][2], [
+            Decimal('22.00'),
+            Decimal('11.00'),
+            '',
+            Decimal('11.00'),
+            Decimal('11.00'),
+            '',
+        ])
+
+    def testWeeklyTotalsSameLastName(self):
+        """Ensure that the totals are aggregated correctly for users with the
+        same last name
+        """
+        User.objects.all().update(last_name='Smith')
         self.all_logs(self.user)
         self.all_logs(self.user2)
         self.login_user(self.superuser)


### PR DESCRIPTION
Fixes #819, TM-819

Entries were only being ordered by `user__last_name`; the groupby functionality must have the entries properly ordered before processing.  Adding the additional `order_by` for `user__first_name` addresses this issue.