### PR TITLE
Broken test fix

### DIFF
--- a/timepiece/crm/tests/test_businesses.py
+++ b/timepiece/crm/tests/test_businesses.py
@@ -103,6 +103,7 @@ class TestDeleteBusiness(ViewTestMixin, TestCase):
 
     def test_bad_pk(self):
         """View should return 404 response if no object is found."""
+        Business.objects.all().delete()
         self.url_kwargs[self.pk_url_kwarg] = 1234
         response = self._get()
         self.assertEquals(response.status_code, 404)
@@ -168,6 +169,7 @@ class TestEditBusiness(ViewTestMixin, TestCase):
 
     def test_bad_pk(self):
         """View should return 404 response if no object is found."""
+        Business.objects.all().delete()
         self.url_kwargs[self.pk_url_kwarg] = 1234
         response = self._get()
         self.assertEquals(response.status_code, 404)
@@ -323,6 +325,7 @@ class TestViewBusiness(ViewTestMixin, TestCase):
 
     def test_bad_pk(self):
         """View should return 404 response if no object is found."""
+        Business.objects.all().delete()
         self.url_kwargs[self.pk_url_kwarg] = 1234
         response = self._get()
         self.assertEquals(response.status_code, 404)

--- a/timepiece/crm/tests/test_project_timesheet.py
+++ b/timepiece/crm/tests/test_project_timesheet.py
@@ -8,6 +8,8 @@ from timepiece import utils
 from timepiece.tests import factories
 from timepiece.tests.base import ViewTestMixin, LogTimeMixin
 
+from ..models import Project
+
 
 class TestProjectTimesheet(ViewTestMixin, LogTimeMixin, TestCase):
     url_name = 'view_project_timesheet'
@@ -52,6 +54,7 @@ class TestProjectTimesheet(ViewTestMixin, LogTimeMixin, TestCase):
         self.assertEqual(response.status_code, 302)
 
     def testNoProject(self):
+        Project.objects.all().delete()
         self.login_user(self.superuser)
         response = self._get(url_args=(999,))
         self.assertEqual(response.status_code, 404)

--- a/timepiece/crm/tests/test_projects.py
+++ b/timepiece/crm/tests/test_projects.py
@@ -109,6 +109,7 @@ class TestDeleteProject(ViewTestMixin, TestCase):
 
     def test_bad_pk(self):
         """View should return 404 response if no object is found."""
+        Project.objects.all().delete()
         self.url_kwargs[self.pk_url_kwarg] = 1234
         response = self._get()
         self.assertEquals(response.status_code, 404)
@@ -180,6 +181,7 @@ class TestEditProject(ViewTestMixin, TestCase):
 
     def test_bad_pk(self):
         """View should return 404 response if no object is found."""
+        Project.objects.all().delete()
         self.url_kwargs[self.pk_url_kwarg] = 1234
         response = self._get()
         self.assertEquals(response.status_code, 404)
@@ -354,6 +356,7 @@ class TestViewProject(ViewTestMixin, TestCase):
 
     def test_bad_pk(self):
         """View should return 404 response if no object is found."""
+        Project.objects.all().delete()
         self.url_kwargs[self.pk_url_kwarg] = 1234
         response = self._get()
         self.assertEquals(response.status_code, 404)

--- a/timepiece/crm/tests/test_users.py
+++ b/timepiece/crm/tests/test_users.py
@@ -156,6 +156,7 @@ class TestDeleteUser(ViewTestMixin, TestCase):
 
     def test_bad_pk(self):
         """View should return 404 response if no object is found."""
+        User.objects.exclude(id=self.user.id).delete()
         self.url_kwargs[self.pk_url_kwarg] = 1234
         response = self._get()
         self.assertEquals(response.status_code, 404)
@@ -229,6 +230,7 @@ class TestEditUser(ViewTestMixin, TestCase):
 
     def test_bad_pk(self):
         """View should return 404 response if no object is found."""
+        User.objects.exclude(id=self.user.id).delete()
         self.url_kwargs[self.pk_url_kwarg] = 1234
         response = self._get()
         self.assertEquals(response.status_code, 404)
@@ -426,6 +428,7 @@ class TestViewUser(ViewTestMixin, TestCase):
 
     def test_bad_pk(self):
         """View should return 404 response if no object is found."""
+        User.objects.exclude(id=self.user.id).delete()
         self.url_kwargs[self.pk_url_kwarg] = 1234
         response = self._get()
         self.assertEquals(response.status_code, 404)


### PR DESCRIPTION
Remove fixture objects before testing 404s for PKs that do not exist in the database