### PR TITLE
TM-834; add pagination to bottom of Businesses, Users, Projects listing pages

### DIFF
--- a/timepiece/templates/timepiece/business/list.html
+++ b/timepiece/templates/timepiece/business/list.html
@@ -43,6 +43,7 @@
                     {% endfor %}
                 </tbody>
             </table>
+            {% include "timepiece/pagination.html" %}
         </div>
     </div>
 {% endblock content %}

--- a/timepiece/templates/timepiece/project/list.html
+++ b/timepiece/templates/timepiece/project/list.html
@@ -47,6 +47,7 @@
                     {% endfor %}
                 </tbody>
             </table>
+            {% include "timepiece/pagination.html" %}
         </div>
     </div>
 {% endblock content %}

--- a/timepiece/templates/timepiece/user/list.html
+++ b/timepiece/templates/timepiece/user/list.html
@@ -58,6 +58,7 @@
                     {% endfor %}
                 </tbody>
             </table>
+            {% include "timepiece/pagination.html" %}
         </div>
     </div>
 {% endblock content %}


### PR DESCRIPTION
At some point during the upgrade, pagination was lost at the bottoms of:

  * `/user`
  * `/project`
  * `/business`