### PR TITLE
Fixing ActivityLookup

### DIFF
--- a/timepiece/entries/lookups.py
+++ b/timepiece/entries/lookups.py
@@ -15,7 +15,7 @@ class ActivityLookup(ModelLookup):
         if project_pk not in [None, '']:
             project = Project.objects.get(pk=project_pk)
             if project and project.activity_group:
-                return project.activity_group.activities.all().filter(name__startswith=term)
+                return project.activity_group.activities.all().filter(name__icontains=term)
         return results
 
     def get_item_label(self, item):

--- a/timepiece/entries/lookups.py
+++ b/timepiece/entries/lookups.py
@@ -12,7 +12,7 @@ class ActivityLookup(ModelLookup):
     def get_query(self, request, term):
         results = super(ActivityLookup, self).get_query(request, term)
         project_pk = request.GET.get('project', None)
-        if project_pk != None and project_pk != '':
+        if project_pk not in [None, '']:
             project = Project.objects.get(pk=project_pk)
             if project and project.activity_group:
                 return project.activity_group.activities.all().filter(name__startswith=term)

--- a/timepiece/entries/lookups.py
+++ b/timepiece/entries/lookups.py
@@ -11,9 +11,11 @@ class ActivityLookup(ModelLookup):
 
     def get_query(self, request, term):
         results = super(ActivityLookup, self).get_query(request, term)
-        project = Project.objects.get(pk=request.GET.get('project', ''))
-        if project and project.activity_group:
-            return project.activity_group.activities.all()
+        project_pk = request.GET.get('project', None)
+        if project_pk != None and project_pk != '':
+            project = Project.objects.get(pk=project_pk)
+            if project and project.activity_group:
+                return project.activity_group.activities.all().filter(name__startswith=term)
         return results
 
     def get_item_label(self, item):

--- a/timepiece/entries/tests/test_lookups.py
+++ b/timepiece/entries/tests/test_lookups.py
@@ -4,6 +4,7 @@ from django.test.client import RequestFactory
 from timepiece.tests import factories
 from timepiece.entries.lookups import ActivityLookup
 
+
 class ActivityLookupTestCase(TestCase):
     """
     Tests that the ActivityLookup used by Selectable is looking up models
@@ -58,9 +59,6 @@ class ActivityLookupTestCase(TestCase):
         activity_group2 = factories.ActivityGroup()
         activity_group2.activities.add(activity3)
         activity_group2.activities.add(activity4)
-
-        project1 = factories.Project(activity_group=activity_group1)
-        project2 = factories.Project(activity_group=activity_group2)
 
         request = RequestFactory().get('/selectable/entries-activitylookup', {
             'project': ''

--- a/timepiece/entries/tests/test_lookups.py
+++ b/timepiece/entries/tests/test_lookups.py
@@ -1,0 +1,81 @@
+from django.test import TestCase
+from django.test.client import RequestFactory
+
+from timepiece.tests import factories
+from timepiece.entries.lookups import ActivityLookup
+
+class ActivityLookupTestCase(TestCase):
+    """
+    Tests that the ActivityLookup used by Selectable is looking up models
+    the way we want it to.
+    """
+
+    def setUp(self):
+        self.lookup = ActivityLookup()
+
+    def test_get_query(self):
+        """
+        Tests whether we get the right results with a non-empty query.
+        """
+        activity1 = factories.Activity(name='foo')
+        activity2 = factories.Activity(name='bar')
+        activity3 = factories.Activity(name='baz')
+        activity4 = factories.Activity(name='qux')
+
+        activity_group = factories.ActivityGroup()
+        activity_group.activities.add(activity1)
+        activity_group.activities.add(activity2)
+        activity_group.activities.add(activity3)
+        activity_group.activities.add(activity4)
+
+        project = factories.Project(activity_group=activity_group)
+
+        request = RequestFactory().get('/selectable/entries-activitylookup', {
+            'project': project.pk
+        })
+
+        data = self.lookup.get_query(request, 'a')
+
+        self.assertNotIn(activity1, data)
+        self.assertIn(activity2, data)
+        self.assertIn(activity3, data)
+        self.assertNotIn(activity4, data)
+
+    def test_get_query_empty(self):
+        """
+        Tests whether a query with no associated project searches the entire
+        set of activities, regardless of project.
+        """
+        activity1 = factories.Activity(name='foo')
+        activity2 = factories.Activity(name='bar')
+        activity3 = factories.Activity(name='baz')
+        activity4 = factories.Activity(name='qux')
+
+        activity_group1 = factories.ActivityGroup()
+        activity_group1.activities.add(activity1)
+        activity_group1.activities.add(activity2)
+
+        activity_group2 = factories.ActivityGroup()
+        activity_group2.activities.add(activity3)
+        activity_group2.activities.add(activity4)
+
+        project1 = factories.Project(activity_group=activity_group1)
+        project2 = factories.Project(activity_group=activity_group2)
+
+        request = RequestFactory().get('/selectable/entries-activitylookup', {
+            'project': ''
+        })
+
+        data = self.lookup.get_query(request, '')
+
+        self.assertIn(activity1, data)
+        self.assertIn(activity2, data)
+        self.assertIn(activity3, data)
+        self.assertIn(activity4, data)
+
+        data = self.lookup.get_query(request, 'a')
+
+        self.assertNotIn(activity1, data)
+        self.assertIn(activity2, data)
+        self.assertIn(activity3, data)
+        self.assertNotIn(activity4, data)


### PR DESCRIPTION
ActivityLookup had two issues:

* If the user had no Project selected, then `''` was passed in as the term, causing the invalid function call `Project.objects.get(pk='')`.
* In any case, even if a Project was selected, nothing in Lookup's `get_query` method was returning a restricted set of results.

Two things are added:

* The default value for `request.GET['project']` is set to `None`, and a guard is added to ensure that the value is non-`None` and non-`''`.
* The successful return value is restricted by the search term.