### PR TITLE
Adding backend rounding function to HourGroupManager summaries method

### DIFF
--- a/timepiece/contracts/models.py
+++ b/timepiece/contracts/models.py
@@ -10,6 +10,7 @@ from django.core.mail import send_mail
 from django.core.urlresolvers import reverse
 from django.db import models
 from django.db.models import Sum
+from django.db.models.expressions import F, Func, Value
 from django.template.loader import render_to_string
 from django.utils.encoding import python_2_unicode_compatible
 
@@ -371,7 +372,9 @@ class HourGroupManager(models.Manager):
         # Get the list of bundle names and hour sums
         bundled_entries = entries.values('activity__activity_bundle',
                                          'activity__activity_bundle__name')
-        bundled_entries = bundled_entries.annotate(Sum('hours'))
+        bundled_entries = bundled_entries.annotate(hours__sum=Sum(
+            Func(F('hours'), Value(2), function='ROUND'))
+        )
         bundled_entries = bundled_entries.order_by(
             'activity__activity_bundle__order', 'activity__activity_bundle__name')
         bundled_totals = list(bundled_entries.values_list(
@@ -382,7 +385,9 @@ class HourGroupManager(models.Manager):
         # Get the list of activity names and hour sums
         activity_entries = entries.values('activity', 'activity__name',
                                           'activity__activity_bundle')
-        activity_entries = activity_entries.annotate(Sum('hours'))
+        activity_entries = activity_entries.annotate(hours__sum=Sum(
+            Func(F('hours'), Value(2), function='ROUND'))
+        )
         activity_entries = activity_entries.order_by('activity')
         activity_totals = list(activity_entries.values_list(
             'activity__name',

--- a/timepiece/templates/timepiece/invoice/_weekly_entry_list_table.html
+++ b/timepiece/templates/timepiece/invoice/_weekly_entry_list_table.html
@@ -28,7 +28,7 @@
             <td>{{ entry.start_time|time }} - {{ entry.end_time|time }} </td>
             <td>{{ entry.project.name }}</td>
             <td>{{ entry.activity.name }}</td>
-            <td class="hours">{{ entry.hours }}</td>
+            <td class="hours">{{ entry.hours|floatformat:"2" }}</td>
             <td title="{{entry.comments}}">{{ entry.comments|truncatewords:12 }}</td>
         </tr>
     {% endfor %}


### PR DESCRIPTION
The InvoiceDetail view's `billable_totals` and `nonbillable_totals` make use of the `summaries` method on the `HourGroupManager`. This serves up a sum of all `hours` values on a bundle of entries by calling the `SUM` function in the DB.

We want the hours in the `(non)billable_totals` to reflect the rounding of those hours to two decimal places. Since the summation is happening on the backend, it makes sense to do the rounding there, too.

This change to the `summaries` function performs that rounding on the backend values. It applies the db function `Sum` not to the raw `hours` value but to the result of `Func(F('hours'), Value(2), function='ROUND')`.

Since `summaries` is only used in that one view, and since there are no tests for it, this change is self-contained and, in theory, complete.