### PR TITLE
docs: Fix simple typo, veritcal -> vertical

### DIFF
--- a/timepiece/static/timepiece/js/handsontable/lib/jQuery-contextMenu/jquery.ui.position.js
+++ b/timepiece/static/timepiece/js/handsontable/lib/jQuery-contextMenu/jquery.ui.position.js
@@ -53,7 +53,7 @@ $.fn.position = function( options ) {
 		basePosition = target.offset();
 	}
 
-	// force my and at to have valid horizontal and veritcal positions
+	// force my and at to have valid horizontal and vertical positions
 	// if a value is missing or invalid, it will be converted to center 
 	$.each( [ "my", "at" ], function() {
 		var pos = ( options[this] || "" ).split( " " );


### PR DESCRIPTION
There is a small typo in timepiece/static/timepiece/js/handsontable/lib/jQuery-contextMenu/jquery.ui.position.js.

Should read `vertical` rather than `veritcal`.

